### PR TITLE
Fix PHP Notices when $rate array is returned empty

### DIFF
--- a/amt/archiver.php
+++ b/amt/archiver.php
@@ -108,10 +108,12 @@ class Archiver {
 
 				// check if we've reached the rate limit
 				$rate = $this->twitter->getLastRateLimitStatus();
-				$str .= $rate['remaining'] . '/' . $rate['limit'] . "\n";
-				if ($rate['remaining'] <= 0) {
-					$str .= 'API limit reached. Try again later.' . "\n";
-					$gotResults = false;
+				if (isset($rate['remaining']) && isset($rate['limit'])) {
+					$str .= $rate['remaining'] . '/' . $rate['limit'] . "\n";
+					if ($rate['remaining'] <= 0) {
+						$str .= 'API limit reached. Try again later.' . "\n";
+						$gotResults = false;
+					}
 				}
 
 			} catch (\Exception $e) {


### PR DESCRIPTION
From times to times, the cron job reported the following PHP Notices:

 PHP Notice:  Undefined index: remaining in /path/to/archive-my-tweets/amt/archiver.php on line 111
 PHP Notice:  Undefined index: limit in /path/to/archive-my-tweets/amt/archiver.php on line 111
 PHP Notice:  Undefined index: remaining in /path/to/archive-my-tweets/amt/archiver.php on line 112

This commit should avoid this to happen when the $rate was not properly retrieved from Twitter
