### PR TITLE
Added RewriteBase / to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,5 @@
 RewriteEngine on
+RewriteBase /
 
 # Single Tweet
 RewriteRule ^([0-9]+)/?$ index.php?id=$1 [L]


### PR DESCRIPTION
On some systems `RewriteBase /` needs to be set in the .htaccess. Otherwise the rewrite rules will end up in a 404 error.

This change should not affected systems where `RewriteBase` is not necessary.

Regards,

gehaxelt
