### PR TITLE
Allow quotes in search field.

### DIFF
--- a/amt/controller.php
+++ b/amt/controller.php
@@ -65,7 +65,7 @@ class Controller {
 		} else if (isset($_GET['q'])) {
 
 			// show search results
-			$searchTerm = htmlentities($_GET['q']);
+			$searchTerm = str_replace('&quot;', '"', htmlentities($_GET['q']));
 			$this->data['pageType'] = 'search';
 			$this->data['search'] = true;
 			$this->data['searchTerm'] = $searchTerm;


### PR DESCRIPTION
Hi,

Commit 20ea19b649d4b481477c1950859f8b7028007843 disabled usage of quotes for searching an exact text (ie. all words, instead of any word).
This commit fixes this with unescaping the quote character.

Regards,
Valentin
